### PR TITLE
fix:修改降级+保活模式下，ant-design-vue按钮点击事件丢失问题

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -312,7 +312,7 @@ function recordEventListeners(iframeWindow: Window) {
     const elementListenerList = sandbox.elementEventCacheMap.get(this);
     if (elementListenerList) {
       const index = elementListenerList?.findIndex((ele) => ele.type === type && ele.handler === handler);
-      elementListenerList.splice(index, 1);
+      index !== -1 && elementListenerList.splice(index, 1);
     }
     if (!elementListenerList?.length) {
       sandbox.elementEventCacheMap.delete(this);


### PR DESCRIPTION
ant-design-vue按钮组件有一个点击水波纹效果，在按钮点击的时候，会先清除一次事件监听，这时wujie在缓存事件时，会进入iframeWindow.Node.prototype.removeEventListener函数里面，由于时间还未监听，index为-1时，elementListenerList.splice(index, 1)错误的移除了其他事件，加入一个判断就好了
- [ ] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过
